### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -14,7 +14,7 @@ export default function Login() {
             rememberMe: formData.rememberMe, 
         };
 
-        console.log("Logging in with:", credentials);
+        console.log("Logging in with:", { email: credentials.email, password: "****", rememberMe: credentials.rememberMe });
         try {
             const response = await login(credentials);
             console.log("Login successful:", response.data);


### PR DESCRIPTION
Fixes [https://github.com/Darknessly1/Pointer/security/code-scanning/1](https://github.com/Darknessly1/Pointer/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead of logging the entire `credentials` object, we should log only non-sensitive information or mask the sensitive parts. In this case, we can log the email and a masked version of the password to avoid exposing sensitive data.

- Replace the logging statement on line 17 to exclude the password or mask it.
- Ensure that the fix does not change the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
